### PR TITLE
Inherit stdio to work in all environments

### DIFF
--- a/tasks/mongoimport.js
+++ b/tasks/mongoimport.js
@@ -31,12 +31,8 @@ module.exports = function(grunt) {
     var child = grunt.util.spawn({
       cmd: 'mongoimport',
           args: args,
-          opts:
-          { stdio:
-              [ process.stdin
-              , process.stout
-              , process.stderr
-              ]
+          opts: { 
+            stdio: 'inherit'
           }
         },
         function (error, result) {


### PR DESCRIPTION
Example of issue: http://stackoverflow.com/questions/15044307/grunt-spawned-process-not-capturing-output
Documentation of using 'inherit' for grunt-spawn: https://www.npmjs.com/package/grunt-spawn

This also fixes a problem my team is having using a grunt runner that does not provide process.stdin