### PR TITLE
Add warnings when options or collections is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,39 +22,37 @@ grunt.loadNpmTasks('grunt-mongoimport');
 ### Overview
 In your project's Gruntfile, add a section named `mongoimport` to the data object passed into `grunt.initConfig()`.
 
-```
+``` javascript
 grunt.initConfig({
-  grunt.initConfig({
-    mongoimport: {
-        options: {
-        db : 'my-store',
-        host : 'localhost', //optional
-        port: '27017', //optional
-        username : 'username', //optional
-        password : 'password',  //optional
-        stopOnError : false,  //optional
-        collections : [
-          { 
-            name : 'user', 
-            type : 'json', 
-            file : 'collection/users.json', 
-            jsonArray : true,  //optional
-            upsert : true,  //optional
-            drop : true  //optional
-          }, 
-          { 
-            name : 'media', 
-            type :'json', 
-            file : 'collection/media.json', 
-            jsonArray : true, 
-            upsert : true,
-            drop : true
-          }
-        ]
-      }
+  mongoimport: {
+    options: {
+      db : 'my-store',
+      host : 'localhost', //optional
+      port: '27017', //optional
+      username : 'username', //optional
+      password : 'password',  //optional
+      stopOnError : false,  //optional
+      collections : [
+        {
+          name : 'user',
+          type : 'json',
+          file : 'collection/users.json',
+          jsonArray : true,  //optional
+          upsert : true,  //optional
+          drop : true  //optional
+        },
+        {
+          name : 'media',
+          type :'json',
+          file : 'collection/media.json',
+          jsonArray : true,
+          upsert : true,
+          drop : true
+        }
+      ]
     }
-  });
-})
+  }
+});
 ```
 
 ## Options
@@ -76,7 +74,7 @@ Forces mongoimport to halt the import operation at the first error rather than c
 ### collection.name
 Specifies the name of the collection for mongoimport to import.
 ### collection.type
-json|csv|tsv Declare the type of export format to import 
+json|csv|tsv Declare the type of export format to import
 ### collection.file
 Specify the location of a file containing the data to import.
 ### collection.fields
@@ -89,5 +87,3 @@ Accept import of data expressed with multiple MongoDB documents within a single 
 Modifies the import process to update existing objects in the database if they match an imported object, while inserting all other objects.
 ### collection.drop
 Modifies the import process so that the target instance drops every collection before importing the collection from the input.
-
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-mongoimport",
   "description": "Grunt task for importing data into mongodb",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "homepage": "https://github.com/andrewkeig/grunt-mongoimport",
   "author": {
     "name": "Andrew Keig",

--- a/tasks/mongoimport.js
+++ b/tasks/mongoimport.js
@@ -5,7 +5,15 @@ module.exports = function(grunt) {
 
   var done = this.async();
   var options = this.options();
-  
+
+  if (!options) {
+    grunt.warn(new Error('Options not found.', 3));
+  }
+
+  if (!options.collections) {
+    grunt.warn(new Error('Collections option not found.', 3))
+  };
+
   async.eachSeries(options.collections, function(collection, callback){
     var args = [];
 
@@ -31,7 +39,7 @@ module.exports = function(grunt) {
     var child = grunt.util.spawn({
       cmd: 'mongoimport',
           args: args,
-          opts: { 
+          opts: {
             stdio: 'inherit'
           }
         },

--- a/tasks/mongoimport.js
+++ b/tasks/mongoimport.js
@@ -1,4 +1,5 @@
 var async = require('async');
+var TASK_ERROR = 3;
 
 module.exports = function(grunt) {
   grunt.registerTask("mongoimport", "Grunt task for importing data into mongodb", function() {
@@ -7,12 +8,16 @@ module.exports = function(grunt) {
   var options = this.options();
 
   if (!options) {
-    grunt.warn(new Error('Options not found.', 3));
+    grunt.warn(new Error('Options not found.', TASK_ERROR));
   }
 
   if (!options.collections) {
-    grunt.warn(new Error('Collections option not found.', 3))
-  };
+    grunt.warn(new Error('Collections option not found.', TASK_ERROR));
+  }
+
+  if (!Array.isArray(options.collections)) {
+    grunt.warn(new Error('Collections must be an array'), TASK_ERROR);
+  }
 
   async.eachSeries(options.collections, function(collection, callback){
     var args = [];


### PR DESCRIPTION
On first use of grunt-mongoimport, I missed that 'collection.name' came from an array. Maybe I just need another level of hand-holding but I thought it would be nice to add a warning when required configuration is missing, rather than throwing `Could not read property 'length' of undefined.`

Also took a sec to clean up the example.

Thanks!
